### PR TITLE
Allow game engine to continue running when encouters a game that throws an error

### DIFF
--- a/client/MircoEngine.js
+++ b/client/MircoEngine.js
@@ -120,7 +120,9 @@ export class MircoEngine {
   }
 
   async playNext() {
+
     let next = this.gameLoader.getNextGame()
+      
     if (!next) {
       console.error('Game buffer empty! Refilling...')
       await this.gameLoader.refillBuffer()
@@ -130,6 +132,7 @@ export class MircoEngine {
         return
       }
     }
+    try  {
 
     const { p5, images } = await this.bootstrapP5(next.manifest)
 
@@ -152,6 +155,11 @@ export class MircoEngine {
     this.ui.gameTimer = setTimeout(() => {
       this.endGame(true) // todo: revist win by default
     }, GAME_DURATION)
+  } catch(err) {
+    console.error(`oh no there was a problem trying to play ${next.manifest?.name || 'un-named game'} \n failed with: \n ${err}`)
+    this.ui.showErrorPlayingGame(next.manifest?.name || 'game')
+    setTimeout(() => this.endGame(true), 3000)
+  }
   }
 
   startGameLoop() {

--- a/client/managers/GameLoader.js
+++ b/client/managers/GameLoader.js
@@ -57,7 +57,7 @@ export class GameLoader {
           assets,
         })
       } catch (err) {
-        console.error(`Failed to load ${nextManifest.name}:`, err)
+        console.error(`Failed to load ${nextManifest.name || 'as no manifest name has been provided'}:`, err)
       }
     }
   }

--- a/client/managers/UIManager.js
+++ b/client/managers/UIManager.js
@@ -75,6 +75,11 @@ export class UIManager {
     this.splashOverlay.style.display = 'none'
   }
 
+  showErrorPlayingGame(gameName = 'game'){
+    const error = this.createOverlay('error-splash-overlay', this.buildErrorInfoHTML(gameName))
+    setTimeout(()=> error.remove(), 3000)
+  }
+
   showGameInfo(manifest, authorNameFallback = 'Someone') {
     this.showInstruction(manifest?.instruction || this.DEFAULT_INSTRUCTION)
 
@@ -187,6 +192,11 @@ export class UIManager {
     this.gameTimer = null
     this.timerProgress.style.transition = 'none'
     this.timerProgress.style.width = '100%'
+  }
+
+  buildErrorInfoHTML(gameName){
+    return `<div class="error-splash-content"><h2>Oh no there was an error playing ${gameName}! <br>
+    onto the next </h2></div>`
   }
 
   buildAuthorInfoHTML(manifest) {

--- a/client/style.css
+++ b/client/style.css
@@ -88,7 +88,7 @@ canvas {
   height: var(--game-height);
 }
 
-.start-splash-overlay {
+.start-splash-overlay, .error-splash-overlay {
   font-family: var(--font-family);
   position: absolute;
   top: 0;
@@ -103,7 +103,12 @@ canvas {
   z-index: 9999;
 }
 
-.splash-content {
+ .error-splash-overlay {
+  background: #ff7f7f;
+  color: white;
+ }
+
+.splash-content, .error-splash-content {
   text-align: center;
 }
 


### PR DESCRIPTION
This PR allows the game engine to continue playing through different games even when one throws an error, currently the engine crashes and we have no more games.


https://github.com/user-attachments/assets/01a6e62d-d80b-4242-890f-2b7585b049df

I tried to keep consistent with the current style let me know if you'd like any changes.